### PR TITLE
refactor: Migrate unit tests from mockito to mocktail

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,6 +27,8 @@ dependencies:
   # isar: *isar_version
   # isar_flutter_libs: *isar_version
 
+  mocktail: ^1.0.3
+
 
 
 dev_dependencies:

--- a/test/data/repositories_impl/todo_repository_impl_test.dart
+++ b/test/data/repositories_impl/todo_repository_impl_test.dart
@@ -1,0 +1,86 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:initiation_task/data/repositories_impl/todo.dart';
+import 'package:initiation_task/domain/entities/todo.dart';
+import 'package:mocktail/mocktail.dart';
+
+// Import the mock and potentially its fallback registration if not already global
+import '../../mocks/mock_hive_todo_data_source.dart';
+
+void main() {
+  // Register fallback values once for all tests in this file
+  setUpAll(() {
+    // Assuming Todo is a complex type used in method arguments for HiveTodoDataSource
+    registerFallbackValue(Todo(key: 0, title: '', createdAt: DateTime.now()));
+  });
+
+  late MockHiveTodoDataSource mockHiveTodoDataSource;
+  late TodoRepositoryImpl todoRepositoryImpl;
+
+  setUp(() {
+    mockHiveTodoDataSource = MockHiveTodoDataSource();
+    todoRepositoryImpl = TodoRepositoryImpl(mockHiveTodoDataSource);
+  });
+
+  group('TodoRepositoryImpl', () {
+    final tTodo = Todo(key: 1, title: 'Test Todo', createdAt: DateTime.now());
+    final tTodoList = [tTodo];
+
+    test('addTodo should call addTodo on the data source', () async {
+      // Arrange
+      // Use `any()` for the Todo argument if specific instance doesn't matter for the stub.
+      when(() => mockHiveTodoDataSource.addTodo(any())).thenAnswer((_) async {});
+
+      // Act
+      await todoRepositoryImpl.addTodo(tTodo);
+
+      // Assert
+      verify(() => mockHiveTodoDataSource.addTodo(tTodo)).called(1);
+    });
+
+    test('deleteTodo should call deleteTodo on the data source', () async {
+      // Arrange
+      when(() => mockHiveTodoDataSource.deleteTodo(any())).thenAnswer((_) async {});
+
+      // Act
+      await todoRepositoryImpl.deleteTodo(tTodo.key);
+
+      // Assert
+      verify(() => mockHiveTodoDataSource.deleteTodo(tTodo.key)).called(1);
+    });
+
+    test('getTodos should call getTodos on the data source and return a list of todos', () async {
+      // Arrange
+      when(() => mockHiveTodoDataSource.getTodos()).thenAnswer((_) async => tTodoList);
+
+      // Act
+      final result = await todoRepositoryImpl.getTodos();
+
+      // Assert
+      expect(result, tTodoList);
+      verify(() => mockHiveTodoDataSource.getTodos()).called(1);
+    });
+
+    test('toggleTodo should call toggleTodo on the data source', () async {
+      // Arrange
+      when(() => mockHiveTodoDataSource.toggleTodo(any())).thenAnswer((_) async {});
+
+      // Act
+      await todoRepositoryImpl.toggleTodo(tTodo.key);
+
+      // Assert
+      verify(() => mockHiveTodoDataSource.toggleTodo(tTodo.key)).called(1);
+    });
+
+    test('updateTodo should call updateTodo on the data source', () async {
+      // Arrange
+      // Use `any()` for key and Todo if specific instances don't matter for the stub.
+      when(() => mockHiveTodoDataSource.updateTodo(any(), any())).thenAnswer((_) async {});
+
+      // Act
+      await todoRepositoryImpl.updateTodo(tTodo.key, tTodo);
+
+      // Assert
+      verify(() => mockHiveTodoDataSource.updateTodo(tTodo.key, tTodo)).called(1);
+    });
+  });
+}

--- a/test/mocks/mock_hive_todo_data_source.dart
+++ b/test/mocks/mock_hive_todo_data_source.dart
@@ -1,0 +1,13 @@
+import 'package:mocktail/mocktail.dart';
+import 'package:initiation_task/data/datasources/todo.dart';
+import 'package:initiation_task/domain/entities/todo.dart';
+
+// Create a MockHiveTodoDataSource class using mocktail
+class MockHiveTodoDataSource extends Mock implements HiveTodoDataSource {}
+
+// It's good practice to register fallback values for custom types
+// if they are used as arguments to mocked methods or as return types
+// for methods that might not be explicitly stubbed in all tests.
+void registerHiveFallbackValues() {
+  registerFallbackValue(Todo(key: 0, title: '', createdAt: DateTime.now()));
+}

--- a/test/mocks/mock_todo_repository.dart
+++ b/test/mocks/mock_todo_repository.dart
@@ -1,0 +1,13 @@
+import 'package:mocktail/mocktail.dart';
+import 'package:initiation_task/domain/repositories/todo.dart';
+import 'package:initiation_task/domain/entities/todo.dart';
+
+// Create a MockTodoRepository class using mocktail
+class MockTodoRepository extends Mock implements TodoRepository {}
+
+// Helper to register fallback values for Todo entities if needed by mocktail
+// for methods returning Future<Todo> or involving complex types.
+// This is generally needed if you have methods that are not void or simple primitives.
+void registerFallbackValues() {
+  registerFallbackValue(Todo(key: 0, title: '', createdAt: DateTime.now()));
+}

--- a/test/presentation/providers/todo_notifier_test.dart
+++ b/test/presentation/providers/todo_notifier_test.dart
@@ -1,0 +1,135 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:initiation_task/domain/entities/todo.dart';
+import 'package:initiation_task/presentation/providers/todo.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../mocks/mock_todo_repository.dart'; // Updated import
+
+void main() {
+  // Register fallback values once for all tests
+  setUpAll(() {
+    registerFallbackValue(Todo(key: 0, title: '', createdAt: DateTime.now(), isDone: false));
+  });
+
+  late MockTodoRepository mockTodoRepository;
+  late ProviderContainer container;
+  // TodoNotifier is implicitly created by the provider, we get it from the container
+
+  setUp(() {
+    mockTodoRepository = MockTodoRepository();
+    container = ProviderContainer(
+      overrides: [
+        todosProvider.overrideWith((ref) => TodoNotifier(mockTodoRepository)),
+      ],
+    );
+    // Initialise a default behavior for getTodos as it's called in constructor
+    when(() => mockTodoRepository.getTodos()).thenAnswer((_) async => []);
+  });
+
+  tearDown(() {
+    container.dispose();
+  });
+
+  group('TodoNotifier', () {
+    final tTodo1 = Todo(key: 1, title: 'Test Todo 1', createdAt: DateTime.now());
+    final tTodo2 = Todo(key: 2, title: 'Test Todo 2', createdAt: DateTime.now());
+
+    test('initial state is empty if repository returns empty list', () async {
+      // Arrange
+      // getTodos is called in constructor, mock is already set up in global setUp
+      // Act
+      final notifier = container.read(todosProvider.notifier);
+      await Future.delayed(Duration.zero); // allow microtasks to complete
+
+      // Assert
+      expect(notifier.debugState, isEmpty);
+      verify(() => mockTodoRepository.getTodos()).called(1);
+    });
+
+    test('loadTodos loads todos from repository and updates state', () async {
+      // Arrange
+      when(() => mockTodoRepository.getTodos()).thenAnswer((_) async => [tTodo1, tTodo2]);
+      final notifier = container.read(todosProvider.notifier); // Re-read or ensure notifier is fresh
+
+      // Act
+      notifier.loadTodos(); // Explicitly call loadTodos
+      await Future.delayed(Duration.zero); // allow microtasks to complete
+
+      // Assert
+      expect(notifier.debugState, [tTodo1, tTodo2]);
+      // getTodos is called once in constructor, and once explicitly
+      verify(() => mockTodoRepository.getTodos()).called(2);
+    });
+
+    test('addTodo adds a todo to state and calls repository', () async {
+      // Arrange
+      final notifier = container.read(todosProvider.notifier);
+      when(() => mockTodoRepository.addTodo(any())).thenAnswer((_) async => {});
+
+      // Act
+      notifier.addTodo(tTodo1);
+
+      // Assert
+      expect(notifier.debugState, [tTodo1]);
+      verify(() => mockTodoRepository.addTodo(tTodo1)).called(1);
+    });
+
+    test('removeTodo removes a todo from state and calls repository', () async {
+      // Arrange
+      final notifier = container.read(todosProvider.notifier);
+      notifier.state = [tTodo1, tTodo2]; // Set initial state
+      when(() => mockTodoRepository.deleteTodo(any())).thenAnswer((_) async => {});
+
+      // Act
+      notifier.removeTodo(tTodo1);
+
+      // Assert
+      expect(notifier.debugState, [tTodo2]);
+      verify(() => mockTodoRepository.deleteTodo(tTodo1.key)).called(1);
+    });
+
+    test('toggleTodo toggles todo isDone status and calls repository', () async {
+      // Arrange
+      final notifier = container.read(todosProvider.notifier);
+      final tTodo = Todo(key: 1, title: 'Test', createdAt: DateTime.now(), isDone: false);
+      notifier.state = [tTodo];
+      when(() => mockTodoRepository.toggleTodo(any())).thenAnswer((_) async => {});
+
+      final toggledTodo = tTodo.copyWith(isDone: true);
+
+      // Act
+      notifier.toggleTodo(key: tTodo.key, todo: toggledTodo);
+
+      // Assert
+      expect(notifier.debugState.first.isDone, true);
+      verify(() => mockTodoRepository.toggleTodo(tTodo.key)).called(1);
+    });
+
+    test('updateTodo updates todo title and calls repository', () async {
+      // Arrange
+      final notifier = container.read(todosProvider.notifier);
+      final tInitialTodo = Todo(key: 1, title: 'Initial', createdAt: DateTime.now());
+      notifier.state = [tInitialTodo];
+
+      final tUpdatedTodo = tInitialTodo.copyWith(title: 'Updated');
+      // Ensure the mock is prepared for the specific updated object or use `any()` if details don't matter for the mock.
+      when(() => mockTodoRepository.updateTodo(tInitialTodo.key, tUpdatedTodo)).thenAnswer((_) async => {});
+
+
+      // Act
+      notifier.updateTodo(key: tInitialTodo.key, todo: tUpdatedTodo);
+
+      // Assert
+      expect(notifier.debugState.first.title, 'Updated');
+      verify(() => mockTodoRepository.updateTodo(tInitialTodo.key, tUpdatedTodo)).called(1);
+    });
+
+    test('loadTodos is called on initialization if state is empty (verified by initial setup)', () async {
+      // This test is essentially covered by the `initial state is empty` test
+      // and the global setUp's when(() => mockTodoRepository.getTodos()).thenAnswer
+      // We verify that getTodos() was called during initialization.
+      verify(() => mockTodoRepository.getTodos()).called(1);
+    });
+  });
+}


### PR DESCRIPTION
- Updated pubspec.yaml to use mocktail instead of mockito.
- Refactored mock implementations (MockTodoRepository, MockHiveTodoDataSource) to use mocktail.
- Updated TodoNotifier and TodoRepositoryImpl tests to use mocktail syntax for stubbing and verification.
- Added necessary `registerFallbackValue` calls for custom types used with mocktail.